### PR TITLE
Python plugin loader: a quick hack to solve the issues of robottestin…

### DIFF
--- a/src/plugins/python/src/PythonPluginLoader.cpp
+++ b/src/plugins/python/src/PythonPluginLoader.cpp
@@ -245,6 +245,12 @@ std::string PythonPluginLoaderImpl::getFileName()
 
 bool PythonPluginLoaderImpl::setup(int argc, char** argv)
 {
+    // reopen the test plugin
+    // This is a quick hack which allows loading multiple python plugins
+    // together to solve the issues of robottestingframework-testrunner
+    // not being able running a test suite with multiple python test cases
+    open(filename);
+
     PyObject* func = PyObject_GetAttrString(pyInstance, "setup");
     if (func == nullptr) {
         return true;


### PR DESCRIPTION
This is a quick hack which allows loading multiple python plugins together to solve the issues of robottestingframework-testrunner not being able running a test suite with multiple python test cases